### PR TITLE
Use a different image for mobile and desktop hero

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -20,9 +20,21 @@ const LCP_BLOCKS = []; // add your LCP blocks to the list
  * @param {Element} main The container element
  */
 function buildHeroBlock(main) {
+  const firstDiv = main.querySelector(':scope > div:first-child');
+  const pictures = firstDiv.querySelectorAll('picture');
+  const firstPicture = pictures[0] ?? null;
+  if (pictures.length === 2) {
+    const secondPicture = pictures[1];
+    const secondSource = secondPicture.querySelector('source:last-of-type');
+    secondSource.setAttribute('media', '(min-width: 1024px)');
+
+    firstPicture.prepend(secondSource);
+  }
+
+  const picture = firstPicture;
+
   const h1 = main.querySelector('h1');
 
-  const picture = main.querySelector('picture');
   // eslint-disable-next-line no-bitwise
   if (h1 && picture && (h1.compareDocumentPosition(picture) & Node.DOCUMENT_POSITION_PRECEDING)) {
     const elems = [picture, h1];


### PR DESCRIPTION
Reimported desktop hero + added a different hero image for mobile (to match live site behaviour). There's a small discrepancy with the live site on intermediate sizes, but it feels more like a bug on the live site.

Test URLs:
- Before: https://main--hyundai-brasil--aemsites.hlx.page/
- After: https://mobilehero--hyundai-brasil--aemsites.hlx.page/
