### PR TITLE
Fix desktop mouseover behaviour

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -239,7 +239,7 @@
   }
 }
 
-@media (width >= 900px) {
+@media (width >= 992px) {
   .cards.header-content.block {
     position: relative;
     top: 5rem;

--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -90,7 +90,7 @@
   border: solid 1px #707070;
 }
 
-@media (width >= 900px) {
+@media (width >= 992px) {
   .form fieldset {
     grid-template-columns: repeat(3, 1fr);
     gap: 16px;

--- a/blocks/header/header-utils.js
+++ b/blocks/header/header-utils.js
@@ -147,9 +147,9 @@ export function addTabs(tabs, block, navFragment, isDesktop) {
     } else {
       button.classList.add('tab');
       tabButton.replaceChildren(button);
-      // TODO check whether we need these "cloneNode"
       // TODO handle "Ofertas" tab
       if (tab.content) {
+        tab.content.classList.add('desktop-only');
         button.after(tab.content);
       }
       enableHover(tabButton, block, button, tab, navPanel, navFragment, isDesktop);

--- a/blocks/header/header-utils.js
+++ b/blocks/header/header-utils.js
@@ -112,6 +112,7 @@ export function enableHover(tabButton, block, button, tab, navPanel, navFragment
     }
     const activeButton = block.querySelector('button.active');
 
+    document.body.classList.remove('nav-open');
     if (!activeButton) {
       button.classList.add('active');
       // add active class to parent li

--- a/blocks/header/header-utils.js
+++ b/blocks/header/header-utils.js
@@ -179,13 +179,10 @@ export function addTabs(tabs, block, navFragment, isDesktop) {
     const { tabButton, title } = tab;
     button.textContent = title.split(',');
     if (button.textContent === 'hamburger') {
-      // eslint-disable-next-line
-      button.innerHTML = '<span class="icon icon-hamburger"><img data-icon-name="hamburger" src="/icons/hamburger.svg" alt="" loading="lazy"></span>';
-      button.classList.add('onlyclick');
-      button.classList.add('tab');
-      tabButton.replaceChildren(button);
-      enableClick(tabButton, block, button, tab, navPanel);
-    } else if (button.textContent === 'hyundai') {
+      console.error('Hamburger tab should have already been handled', tab);
+      return;
+    }
+    if (button.textContent === 'hyundai') {
       // eslint-disable-next-line
       button.innerHTML='<span class="icon icon-hyundai"><img data-icon-name="hyundai" src="/icons/hyundai.svg" alt="" loading="lazy"></span>';
       button.classList.add('onlyclick');

--- a/blocks/header/header-utils.js
+++ b/blocks/header/header-utils.js
@@ -56,30 +56,6 @@ export function createTabs(block, navFragment) {
 }
 
 export function enableHover(tabButton, block, button, tab, navPanel, navFragment, isDesktop) {
-  function disableHoverEffect(activeButton) {
-    activeButton.classList.remove('active');
-    // remove active class from parent li
-    activeButton.parentElement.classList.remove('active');
-    if (tab.content) {
-      tab.content.classList.remove('active');
-      if (navPanel.nextSibling) navPanel.nextSibling.remove();
-    }
-  }
-
-  document.querySelector('main .section.columns-container').addEventListener('mouseover', () => {
-    const activeButton = block.querySelector('button.active');
-    if (activeButton) {
-      disableHoverEffect(activeButton);
-    }
-  });
-
-  navFragment.querySelector('div:not(.section.nav-sections)').addEventListener('mouseover', () => {
-    const activeButton = block.querySelector('button.active');
-    if (activeButton) {
-      disableHoverEffect(activeButton);
-    }
-  });
-
   tabButton.addEventListener('click', () => {
     if (isDesktop.matches) {
       return;
@@ -110,28 +86,8 @@ export function enableHover(tabButton, block, button, tab, navPanel, navFragment
     if (!isDesktop.matches) {
       return;
     }
-    const activeButton = block.querySelector('button.active');
 
     document.body.classList.remove('nav-open');
-    if (!activeButton) {
-      button.classList.add('active');
-      // add active class to parent li
-      tabButton.classList.add('active');
-      if (tab.content) {
-        tab.content.classList.add('active');
-        navPanel.after(tab.content);
-        navPanel.nextSibling.classList.add('tab-active');
-      }
-    } else if (activeButton !== tabButton) {
-      disableHoverEffect(activeButton);
-      button.classList.add('active');
-      // add active class to parent li
-      tabButton.classList.add('active');
-      if (tab.content) {
-        tab.content.classList.add('active');
-        navPanel.after(tab.content);
-      }
-    }
   });
 }
 
@@ -195,10 +151,9 @@ export function addTabs(tabs, block, navFragment, isDesktop) {
       // TODO check whether we need these "cloneNode"
       // TODO handle "Ofertas" tab
       if (tab.content) {
-        console.log('tab', tab.title, tab.content);
-        button.after(tab.content.cloneNode(true));
+        button.after(tab.content);
       }
-      // enableHover(tabButton, block, button, tab, navPanel, navFragment, isDesktop);
+      enableHover(tabButton, block, button, tab, navPanel, navFragment, isDesktop);
     }
   });
 }

--- a/blocks/header/header-utils.js
+++ b/blocks/header/header-utils.js
@@ -192,7 +192,13 @@ export function addTabs(tabs, block, navFragment, isDesktop) {
     } else {
       button.classList.add('tab');
       tabButton.replaceChildren(button);
-      enableHover(tabButton, block, button, tab, navPanel, navFragment, isDesktop);
+      // TODO check whether we need these "cloneNode"
+      // TODO handle "Ofertas" tab
+      if (tab.content) {
+        console.log('tab', tab.title, tab.content);
+        button.after(tab.content.cloneNode(true));
+      }
+      // enableHover(tabButton, block, button, tab, navPanel, navFragment, isDesktop);
     }
   });
 }

--- a/blocks/header/header-utils.js
+++ b/blocks/header/header-utils.js
@@ -55,7 +55,7 @@ export function createTabs(block, navFragment) {
   return tabs;
 }
 
-export function enableHover(tabButton, block, button, tab, navPanel, navFragment, isDesktop) {
+export function setUpTabListeners(tabButton, block, button, tab, navPanel, navFragment, isDesktop) {
   tabButton.addEventListener('click', () => {
     if (isDesktop.matches) {
       return;
@@ -87,44 +87,6 @@ export function enableHover(tabButton, block, button, tab, navPanel, navFragment
   });
 }
 
-export function enableClick(tabButton, block, button, tab, navPanel) {
-  tabButton.addEventListener('click', () => {
-    const activeButton = block.querySelector('button.active');
-    if (!activeButton) {
-      button.classList.add('active');
-      // add active class to parent li
-      tabButton.classList.add('active');
-      if (tab.content) {
-        tab.content.classList.add('active');
-        navPanel.after(tab.content);
-        navPanel.nextSibling.classList.add('tab-active');
-      }
-    } else if (activeButton !== tabButton.firstChild) {
-      activeButton.classList.remove('active');
-      // remove active class from parent li
-      activeButton.parentElement.classList.remove('active');
-      if (tab.content) {
-        tab.content.classList.remove('active');
-        navPanel.nextSibling.remove();
-      }
-      button.classList.add('active');
-      // add active class to parent li
-      tabButton.classList.add('active');
-      if (tab.content) {
-        tab.content.classList.add('active');
-        navPanel.after(tab.content);
-      }
-    } else {
-      button.classList.remove('active');
-      tabButton.classList.remove('active');
-      if (tab.content) {
-        tab.content.classList.remove('active');
-        navPanel.nextSibling.remove();
-      }
-    }
-  });
-}
-
 export function addTabs(tabs, block, navFragment, isDesktop) {
   const navPanel = navFragment.querySelector('.section.nav-sections').parentElement;
   tabs.forEach((tab) => {
@@ -152,7 +114,7 @@ export function addTabs(tabs, block, navFragment, isDesktop) {
         tab.content.classList.add('desktop-only');
         button.after(tab.content);
       }
-      enableHover(tabButton, block, button, tab, navPanel, navFragment, isDesktop);
+      setUpTabListeners(tabButton, block, button, tab, navPanel, navFragment, isDesktop);
     }
   });
 }

--- a/blocks/header/header-utils.js
+++ b/blocks/header/header-utils.js
@@ -70,12 +70,8 @@ export function enableHover(tabButton, block, button, tab, navPanel, navFragment
     mobileSectionHeader.textContent = tab.title;
     const mobileBody = document.querySelector('.item-mobile-body');
 
-    // remove diacritics
-    const normalizedTitle = tab.title.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-    const sanitizedTitle = toClassName(normalizedTitle);
-
     mobileBody.replaceWith(div(
-      { class: `item-mobile-body ${sanitizedTitle}` },
+      { class: `item-mobile-body ${toClassName(tab.title)}` },
       ...tab.content.cloneNode(true).children,
     ));
 
@@ -139,6 +135,9 @@ export function addTabs(tabs, block, navFragment, isDesktop) {
       console.error('Hamburger tab should have already been handled', tab);
       return;
     }
+
+    tabButton.classList.add(toClassName(title));
+
     if (button.textContent === 'hyundai') {
       // eslint-disable-next-line
       button.innerHTML='<span class="icon icon-hyundai"><img data-icon-name="hyundai" src="/icons/hyundai.svg" alt="" loading="lazy"></span>';

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -10,6 +10,15 @@ header nav {
   font-family: var(--body-font-family);
 }
 
+header nav .hamburger-tab.tab-item {
+  display: none;
+}
+
+body.nav-open header nav .hamburger-tab.tab-item {
+  display: flex;
+  left: 0;
+}
+
 header nav span.icon-hyundai {
   display: none;
 }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -119,6 +119,11 @@ header nav .nav-sections ul > li > ul > li {
   font-weight: 500;
 }
 
+header nav .nav-sections .hero-horiz-tabs-nav > ul:last-child > li:last-child {
+  background-color: var(--primary-color);
+  border: solid 1px var(--primary-color);
+}
+
 header nav .nav-sections ul:last-of-type > li:last-of-type > button {
   min-width: 166px;
   color: #fff;
@@ -126,16 +131,16 @@ header nav .nav-sections ul:last-of-type > li:last-of-type > button {
   padding: 26px 20px;
 }
 
-header nav .nav-sections ul:last-of-type > li:not(:last-of-type):hover, header nav .nav-sections ul:last-of-type > li:not(:last-of-type) > button:hover,
-header nav .nav-sections ul:last-of-type > li:not(:last-of-type):focus, header nav .nav-sections ul:last-of-type > li:not(:last-of-type) > button:focus {
+header nav .nav-sections .hero-horiz-tabs-nav > ul:last-of-type > li:not(:last-of-type):hover, header nav .nav-sections ul:last-of-type > li:not(:last-of-type) > button:hover,
+header nav .nav-sections .hero-horiz-tabs-nav > ul:last-of-type > li:not(:last-of-type):focus, header nav .nav-sections ul:last-of-type > li:not(:last-of-type) > button:focus {
   background-color: white;
   transition: all .4s ease-out;
   color: black;
   cursor: pointer;
 }
 
-header nav .nav-sections ul:last-of-type > li:last-of-type:hover, header nav .nav-sections ul:last-of-type > li:last-of-type > button:hover,
-header nav .nav-sections ul:last-of-type > li:last-of-type:focus, header nav .nav-sections ul:last-of-type > li:last-of-type > button:focus {
+header nav .nav-sections .hero-horiz-tabs-nav > ul:last-of-type > li:last-of-type:hover, header nav .nav-sections ul:last-of-type > li:last-of-type > button:hover,
+header nav .nav-sections .hero-horiz-tabs-nav > ul:last-of-type > li:last-of-type:focus, header nav .nav-sections ul:last-of-type > li:last-of-type > button:focus {
   background-color: #fff;
   color: var(--primary-color);
   transition: all .4s ease-out;
@@ -146,17 +151,12 @@ header nav .nav-sections .hero-horiz-tabs-nav {
   gap:10vw;
 }
 
-header nav .nav-sections .hero-horiz-tabs-nav > ul:last-child > li:not(:first-child) > .tab-item {
+header nav .nav-sections .hero-horiz-tabs-nav > ul:last-child > li > .tab-item {
   display: none;
 }
 
 header nav .nav-sections .hero-horiz-tabs-nav > ul:last-child > li:hover > .tab-item {
   display: flex;
-}
-
-header nav .nav-sections .hero-horiz-tabs-nav > ul:last-child li:last-child {
-  background-color: var(--primary-color);
-  border: solid 1px var(--primary-color);
 }
 
 @media (width >= 600px) {
@@ -337,7 +337,7 @@ header nav .nav-sections ul > li > ul {
     height: calc(100vh - var(--nav-height));
     box-shadow: 0 3px 10px 0 rgb(216 209 200 / 40%);
     line-height: 1.5;
-    transition: transform .5s ease-out, height 1s ease-in, visibility 1s ease-in;
+    transition: transform .5s ease-out, height .5s ease-in, visibility .5s ease-in;
   }
 
   header nav .section.mobile {
@@ -474,6 +474,11 @@ header nav .nav-sections ul > li > ul {
     font-weight: 600;
     justify-content: flex-start;
     font-size: inherit;
+  }
+
+  /* Undo desktop style */
+  a.button:not(.onlyclick):hover, a.button:not(.onlyclick):focus, button:not(.onlyclick):hover, button:not(.onlyclick):focus {
+    background-color: inherit;
   }
 
   header nav .nav-sections ul:first-child li button {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -80,13 +80,13 @@ header nav[aria-expanded="true"] {
 header .tab-item {
   position: fixed;
   background: white;
-  width: 100%;
+  left: 0;
+  width: 100vw;
   height: 25rem;
   display: flex;
   flex-direction: row;
   box-shadow: 0 8px 16px 0 rgb(0 0 0 / 20%), 0 6px 20px 0 rgba(0 0 0 / 19%);
 }
-
 
 header .tab-item:has(.image) {
   height: 37rem;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -165,7 +165,7 @@ header nav .nav-sections .hero-horiz-tabs-nav > ul:last-child > li:hover > .tab-
   }
 }
 
-@media (width >= 900px) {
+@media (width >= 992px) {
   header .section.nav-brand {
     display: none;
   }
@@ -266,7 +266,7 @@ header nav[aria-expanded="true"] .nav-hamburger-icon::after {
   transform: rotate(-45deg);
 }
 
-@media (width >= 900px) {
+@media (width >= 992px) {
   header nav .nav-hamburger {
     display: none;
     visibility: hidden;
@@ -307,7 +307,7 @@ header nav .nav-sections ul > li > ul {
 }
 
 /* TODO use as default config - temp workaround to work faster */
-@media (width < 900px) {
+@media (width < 992px) {
   header nav {
     padding: 0;
     height: auto;
@@ -485,7 +485,6 @@ header nav .nav-sections ul > li > ul {
     padding-left: 10px;
   }
 
-
   header nav .nav-sections .main-tab ul:last-child li {
     display: block;
     padding: 0;
@@ -525,7 +524,7 @@ header nav .nav-sections ul > li > ul {
   }
 }
 
-@media (width >= 900px) {
+@media (width >= 992px) {
   header .icon-ofertas,
   header .icon-arrow {
     display: none;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -146,6 +146,14 @@ header nav .nav-sections .hero-horiz-tabs-nav {
   gap:10vw;
 }
 
+header nav .nav-sections .hero-horiz-tabs-nav > ul:last-child > li:not(:first-child) > .tab-item {
+  display: none;
+}
+
+header nav .nav-sections .hero-horiz-tabs-nav > ul:last-child > li:hover > .tab-item {
+  display: flex;
+}
+
 header nav .nav-sections .hero-horiz-tabs-nav > ul:last-child li:last-child {
   background-color: var(--primary-color);
   border: solid 1px var(--primary-color);

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -4,7 +4,7 @@ import { addTabs, createTabs } from './header-utils.js';
 import { div, img, span } from '../../scripts/dom-helpers.js';
 
 // media query match that indicates mobile/tablet width
-const isDesktop = window.matchMedia('(min-width: 900px)');
+const isDesktop = window.matchMedia('(min-width: 992px)');
 
 function closeOnEscape(e) {
   if (e.code === 'Escape') {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -190,7 +190,7 @@ export default async function decorate(block) {
   });
 
   const clonedTab = hamburgerTab.content.cloneNode(true);
-  const mobileHamburgerSection = div({ class: 'mobile-only main-tab' }, ...clonedTab.querySelectorAll('ul'));
+  const mobileHamburgerSection = div({ class: 'mobile-only main-tab' }, ...[...clonedTab.querySelectorAll('ul')].map((ul) => ul.cloneNode(true)));
   heroHorizTabsNav.after(mobileHamburgerSection);
 
   const hyundaiBlueSpan = span({ class: 'icon icon-hyundai-blue' });

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -222,10 +222,6 @@ export default async function decorate(block) {
   hamburger.addEventListener('click', () => {
     function toggleNav() {
       document.body.classList.toggle('nav-open');
-      if (!isDesktop.matches) {
-        // navPanel.classList.toggle('show');
-        /* wait for 2 seconds */
-      }
       toggleMenu(nav, navSections);
     }
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,6 +1,6 @@
 import { decorateIcons, getMetadata } from '../../scripts/aem.js';
 import { loadFragment } from '../fragment/fragment.js';
-import { addTabs, createTabs } from './header-utils.js';
+import { addTabs, createTabs, enableClick } from './header-utils.js';
 import { div, img, span } from '../../scripts/dom-helpers.js';
 
 // media query match that indicates mobile/tablet width
@@ -141,6 +141,22 @@ export default async function decorate(block) {
     ),
   );
 
+  const hamburgerTab = tabs.find((t) => t.title === 'hamburger');
+  tabs.splice(tabs.indexOf(hamburgerTab), 1);
+
+  console.log('found hamburger tab', hamburgerTab);
+  {
+    const button = document.createElement('button');
+    const { tabButton } = hamburgerTab;
+    button.textContent = 'hamburger';
+    // eslint-disable-next-line
+    button.innerHTML = '<span class="icon icon-hamburger"><img data-icon-name="hamburger" src="/icons/hamburger.svg" alt="" loading="lazy"></span>';
+    button.classList.add('onlyclick');
+    button.classList.add('tab');
+    tabButton.replaceChildren(button);
+    enableClick(tabButton, block, button, hamburgerTab, navPanel);
+  }
+
   addTabs(tabs, block, nav, isDesktop);
 
   navSections.querySelectorAll(':scope .default-content-wrapper > ul > li').forEach((navSection) => {
@@ -154,7 +170,7 @@ export default async function decorate(block) {
     });
   });
 
-  const clonedTab = tabs.find((t) => t.name === 'hamburger').content.cloneNode(true);
+  const clonedTab = hamburgerTab.content.cloneNode(true);
   const mobileHamburgerSection = div({ class: 'mobile-only main-tab' }, ...clonedTab.querySelectorAll('ul'));
   navSections.querySelector('.hero-horiz-tabs-nav').after(mobileHamburgerSection);
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,6 +1,6 @@
 import { decorateIcons, getMetadata } from '../../scripts/aem.js';
 import { loadFragment } from '../fragment/fragment.js';
-import { addTabs, createTabs, enableClick } from './header-utils.js';
+import { addTabs, createTabs } from './header-utils.js';
 import { div, img, span } from '../../scripts/dom-helpers.js';
 
 // media query match that indicates mobile/tablet width
@@ -144,17 +144,36 @@ export default async function decorate(block) {
   const hamburgerTab = tabs.find((t) => t.title === 'hamburger');
   tabs.splice(tabs.indexOf(hamburgerTab), 1);
 
+  const heroHorizTabsNav = navSections.querySelector('.hero-horiz-tabs-nav');
+
   console.log('found hamburger tab', hamburgerTab);
   {
     const button = document.createElement('button');
-    const { tabButton } = hamburgerTab;
+    const { tabButton, content } = hamburgerTab;
+    const clonedContent = content.cloneNode(true);
+    clonedContent.classList.add('hamburger-tab', 'desktop-only');
+    heroHorizTabsNav.after(clonedContent);
+
     button.textContent = 'hamburger';
     // eslint-disable-next-line
     button.innerHTML = '<span class="icon icon-hamburger"><img data-icon-name="hamburger" src="/icons/hamburger.svg" alt="" loading="lazy"></span>';
     button.classList.add('onlyclick');
     button.classList.add('tab');
     tabButton.replaceChildren(button);
-    enableClick(tabButton, block, button, hamburgerTab, navPanel);
+    // enableClick(tabButton, block, button, hamburgerTab, navPanel);
+    button.addEventListener('click', () => {
+      function toggleNav() {
+        document.body.classList.toggle('nav-open');
+        toggleMenu(nav, navSections);
+      }
+
+      if (navPanel.classList.contains('show-mobile-section')) {
+        navPanel.classList.remove('show-mobile-section');
+        setTimeout(toggleNav, 500);
+      } else {
+        toggleNav();
+      }
+    });
   }
 
   addTabs(tabs, block, nav, isDesktop);
@@ -172,7 +191,7 @@ export default async function decorate(block) {
 
   const clonedTab = hamburgerTab.content.cloneNode(true);
   const mobileHamburgerSection = div({ class: 'mobile-only main-tab' }, ...clonedTab.querySelectorAll('ul'));
-  navSections.querySelector('.hero-horiz-tabs-nav').after(mobileHamburgerSection);
+  heroHorizTabsNav.after(mobileHamburgerSection);
 
   const hyundaiBlueSpan = span({ class: 'icon icon-hyundai-blue' });
   nav.querySelector('span.icon-hyundai').after(hyundaiBlueSpan);

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -190,24 +190,23 @@ export default async function decorate(block) {
   });
 
   const clonedTab = hamburgerTab.content.cloneNode(true);
-  const mobileHamburgerSection = div({ class: 'mobile-only main-tab' }, ...[...clonedTab.querySelectorAll('ul')].map((ul) => ul.cloneNode(true)));
+  const mobileHamburgerSection = div({ class: 'mobile-only main-tab' }, ...clonedTab.querySelectorAll('ul'));
   heroHorizTabsNav.after(mobileHamburgerSection);
 
   const hyundaiBlueSpan = span({ class: 'icon icon-hyundai-blue' });
   nav.querySelector('span.icon-hyundai').after(hyundaiBlueSpan);
 
   nav.querySelectorAll('nav.hero-horiz-tabs-nav > ul > li:not(:last-child)').forEach((li) => {
-    li.append(span({ class: 'icon icon-arrow' }));
+    li.append(span({ class: 'icon icon-arrow mobile-only' }));
   });
   nav.querySelector('nav.hero-horiz-tabs-nav > ul > li:last-child').append(img(
-    { class: 'icon-ofertas', src: '/icons/ofertas.avif', alt: 'Icon ofertas' },
+    { class: 'icon-ofertas mobile-only', src: '/icons/ofertas.avif', alt: 'Icon ofertas' },
   ));
   decorateIcons(nav);
 
   if (isDesktop.matches) {
     const rightNavSection = document.createElement('ul');
-    nav.querySelectorAll('.section.nav-sections .hero-horiz-tabs-nav ul > li:not(:has(button.onlyclick))');
-    nav.querySelectorAll('.section.nav-sections .hero-horiz-tabs-nav ul > li:not(:has(button.onlyclick))').forEach((x) => {
+    nav.querySelectorAll('.section.nav-sections .hero-horiz-tabs-nav > ul > li:not(:has(button.onlyclick))').forEach((x) => {
       rightNavSection.appendChild(x);
     });
     const parent = nav.querySelector('.section.nav-sections .hero-horiz-tabs-nav');

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -203,14 +203,12 @@ export default async function decorate(block) {
   ));
   decorateIcons(nav);
 
-  if (isDesktop.matches) {
-    const rightNavSection = document.createElement('ul');
-    nav.querySelectorAll('.section.nav-sections .hero-horiz-tabs-nav > ul > li:not(:has(button.onlyclick))').forEach((x) => {
-      rightNavSection.appendChild(x);
-    });
-    const parent = nav.querySelector('.section.nav-sections .hero-horiz-tabs-nav');
-    parent.appendChild(rightNavSection);
-  }
+  const rightNavSection = document.createElement('ul');
+  nav.querySelectorAll('.section.nav-sections .hero-horiz-tabs-nav > ul > li:not(:has(button.onlyclick))').forEach((x) => {
+    rightNavSection.appendChild(x);
+  });
+  const parent = nav.querySelector('.section.nav-sections .hero-horiz-tabs-nav');
+  parent.appendChild(rightNavSection);
 
   // hamburger for mobile
   const hamburger = document.createElement('div');

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -146,7 +146,7 @@ export default async function decorate(block) {
 
   const heroHorizTabsNav = navSections.querySelector('.hero-horiz-tabs-nav');
 
-  console.log('found hamburger tab', hamburgerTab);
+  // hamburger tab logic
   {
     const button = document.createElement('button');
     const { tabButton, content } = hamburgerTab;
@@ -160,7 +160,6 @@ export default async function decorate(block) {
     button.classList.add('onlyclick');
     button.classList.add('tab');
     tabButton.replaceChildren(button);
-    // enableClick(tabButton, block, button, hamburgerTab, navPanel);
     button.addEventListener('click', () => {
       function toggleNav() {
         document.body.classList.toggle('nav-open');

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -175,6 +175,8 @@ function init() {
 function toClassName(name) {
   return typeof name === 'string'
     ? name
+      // extra logic to convert diacritics
+      .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
       .toLowerCase()
       .replace(/[^0-9a-z]/gi, '-')
       .replace(/-+/g, '-')

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -209,7 +209,7 @@ async function loadLazy(doc) {
  */
 function loadDelayed() {
   // eslint-disable-next-line import/no-cycle
-  window.setTimeout(() => import('./delayed.js'), 4000);
+  window.setTimeout(() => import('./delayed.js'), 5000);
   // load anything that can be postponed to the latest here
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -172,7 +172,7 @@ async function loadEager(doc) {
 
   try {
     /* if desktop (proxy for fast connection) or fonts already loaded, load fonts.css */
-    if (window.innerWidth >= 900 || sessionStorage.getItem('fonts-loaded')) {
+    if (window.innerWidth >= 992 || sessionStorage.getItem('fonts-loaded')) {
       loadFonts();
     }
   } catch (e) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -258,6 +258,12 @@ main .section {
   }
 }
 
+@media (width < 992px) {
+  .desktop-only {
+    display: none !important;
+  }
+}
+
 @media (width >= 992px) {
   .mobile-only {
     display: none !important;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -75,7 +75,7 @@ html {
   src: local('Arial');
 }
 
-@media (width >= 900px) {
+@media (width >= 992px) {
   :root {
     --heading-font-size-xxl: 39px;
     --heading-font-size-xl: 22px;


### PR DESCRIPTION
New features:
- Hamburger tab does not close on mouseover gone
- Other tabs close automatically when ending mouseover is gone (even if the mouse goes to a non-button part of the header)
- Add classes to each tab "li" to simplify development (veiculos, propietarios, ...)

Test URLs:
- Before: https://main--hyundai-brasil--aemsites.hlx.page/
- After: https://feature-unifyheader--hyundai-brasil--aemsites.hlx.page/
